### PR TITLE
Replicate pyapp's runtime isolation guarantees

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,22 @@
 # Changelog
 
+## Unreleased
+
+### Enhancements
+
+- Run apps in Python isolated mode for every entrypoint kind: console-script
+  entrypoints now strip `PYTHON*` variables and disable user site-packages,
+  matching what `-I` already did for module and spec entrypoints
+- Isolate the first-run bootstrap from the user's environment: `UV_*`,
+  `PIP_*`, `PYTHON*`, `VIRTUAL_ENV`, and `CONDA_PREFIX` no longer influence
+  uv during installation (the uv analogue of `pip --isolated`)
+- Install embedded wheels in a deterministic (sorted) order
+
+### Documentation
+
+- Document the runtime flow in `docs/runtime.md`, mirroring pyapp's runtime
+  behavior page with axe's offline-specialized flowchart
+
 ## 0.2.1
 
 ### Enhancements

--- a/README.md
+++ b/README.md
@@ -65,6 +65,11 @@ keyed by payload fingerprint, so a new binary version gets a fresh
 environment automatically. Subsequent runs are a single existence check, then
 `execvp` straight into your app.
 
+The full runtime flow — and how it maps onto pyapp's — is documented in
+[`docs/runtime.md`](docs/runtime.md). Apps run in Python's isolated mode, so
+the user's `PYTHONPATH`, user site-packages, and uv/pip configuration never
+leak in.
+
 Because dependencies are shipped as wheels, every dependency must publish a
 wheel for each target platform (pure-Python wheels cover all of them).
 Binaries weigh roughly 45–60 MB — that's a complete CPython plus uv; disk is

--- a/docs/runtime.md
+++ b/docs/runtime.md
@@ -1,8 +1,7 @@
 # Runtime behavior
 
-Axe's runtime stub replicates [pyapp](https://ofek.dev/pyapp/latest/runtime/)'s
-runtime behavior, rewritten in Go and specialized for axe's design: everything
-the app needs is embedded in the binary, so every network-dependent branch of
+Axe's runtime behavior is rewritten in Go: everything the app needs
+is embedded in the binary, so every network-dependent branch of
 pyapp's flow disappears.
 
 ## Initialization

--- a/docs/runtime.md
+++ b/docs/runtime.md
@@ -1,0 +1,88 @@
+# Runtime behavior
+
+Axe's runtime stub replicates [pyapp](https://ofek.dev/pyapp/latest/runtime/)'s
+runtime behavior, rewritten in Go and specialized for axe's design: everything
+the app needs is embedded in the binary, so every network-dependent branch of
+pyapp's flow disappears.
+
+## Initialization
+
+Binaries bootstrap themselves on the first run. All subsequent invocations
+only check that the installation marker exists and nothing else, to maximize
+CLI responsiveness.
+
+The nodes with rounded edges are conditions and those with jagged edges are
+actions.
+
+```mermaid
+flowchart TD
+    SELF([self command invoked]) -- Yes --> MANAGE[[Run management command]]
+    SELF -- No --> INSTALLED([Installed])
+    INSTALLED -- Yes --> EXECUTE[[Execute project]]
+    INSTALLED -- No --> LOCK[[Acquire bootstrap lock]]
+    LOCK --> UVCACHED([uv cached])
+    UVCACHED -- No --> UVEXTRACT[[Extract embedded uv into shared cache]]
+    UVCACHED -- Yes --> PYEXTRACT[[Extract embedded CPython]]
+    UVEXTRACT --> PYEXTRACT
+    PYEXTRACT --> WHEELS[[Extract embedded wheels]]
+    WHEELS --> VENV[[Create virtual environment]]
+    VENV --> INSTALL[[Install wheels offline]]
+    INSTALL --> MARKER[[Write completion marker]]
+    MARKER --> EXECUTE
+```
+
+Step by step:
+
+- **Installed** — a single `stat` of the `.axe-installed` marker inside the
+  installation directory (`<data dir>/<app name>/<payload fingerprint>`). A
+  new binary version has a new fingerprint, so it gets a fresh environment
+  automatically. `AXE_DATA_DIR` overrides the base directory.
+- **Bootstrap lock** — concurrent first runs are serialized with an
+  exclusively-created lock file; stale locks from crashed processes are
+  reclaimed. A directory without the completion marker is treated as crash
+  residue and rebuilt from scratch.
+- **uv cached** — the embedded uv release archive is extracted once into a
+  shared cache (`<cache dir>/uv/<version>`) and reused by every axe app
+  pinning the same uv version. `AXE_CACHE_DIR` overrides the location,
+  `AXE_UV` bypasses it entirely.
+- **Extract / venv / install** — the embedded python-build-standalone
+  distribution and dependency wheels are unpacked, then uv creates the venv
+  and installs the app with `--offline --no-index --find-links`. The runtime
+  contains no network code at all.
+- **Execute / manage** — `self` is the reserved management command group
+  (`remove`, `restore`, `update` always; `python`, `python-path`, `cache`,
+  `metadata` when exposed at build time); everything else goes to the app.
+
+### Differences from pyapp
+
+pyapp's conditions that axe resolves at *build* time instead of runtime:
+
+| pyapp runtime condition | axe |
+| --- | --- |
+| Distribution cached / embedded / from source | always embedded |
+| Full isolation | not supported; always a venv |
+| UV enabled / UV cached / download UV | uv always embedded, cached on first run |
+| External pip / pip cached / download pip | uv only |
+| Project embedded / dependency file / single project | project + dependency wheels always embedded |
+| Management enabled | always enabled as `self` |
+
+## Execution
+
+Projects are executed using `execvp` on non-Windows systems, replacing the
+process. On Windows the app runs as a child process and its exit code is
+forwarded.
+
+To provide consistent behavior on each user's machine:
+
+- Python runs projects in [isolated mode](https://docs.python.org/3/using/cmdline.html#cmdoption-I).
+  Module (`-m pkg`) and spec (`pkg.mod:func`) entrypoints pass `-I` directly;
+  console-script entrypoints get the environment equivalent (all `PYTHON*`
+  variables are stripped, user site-packages and script-dir `sys.path`
+  prepending are disabled).
+- During installation, uv runs with configuration and environment influence
+  disabled — the uv analogue of pip's `--isolated`: `UV_NO_CONFIG=1`,
+  `UV_OFFLINE=1`, and any inherited `UV_*`, `PIP_*`, `PYTHON*`,
+  `VIRTUAL_ENV`, or `CONDA_PREFIX` variables are dropped.
+
+The app's environment gets `AXE=1` so it can detect axe installs;
+`AXE_DEBUG=1` makes the stub verbose.

--- a/docs/runtime.md
+++ b/docs/runtime.md
@@ -1,8 +1,7 @@
 # Runtime behavior
 
 Axe's runtime behavior is rewritten in Go: everything the app needs
-is embedded in the binary, so every network-dependent branch of
-pyapp's flow disappears.
+is embedded in the binary.
 
 ## Initialization
 

--- a/docs/runtime.md
+++ b/docs/runtime.md
@@ -66,8 +66,9 @@ pyapp's conditions that axe resolves at *build* time instead of runtime:
 
 ## Execution
 
-Projects are executed using `execvp` on non-Windows systems, replacing the
-process. On Windows the app runs as a child process and its exit code is
+Projects are executed using `execve` on non-Windows systems, replacing the
+process (the entrypoint path is already fully resolved, so no PATH lookup is
+involved). On Windows the app runs as a child process and its exit code is
 forwarded.
 
 To provide consistent behavior on each user's machine:

--- a/docs/runtime.md
+++ b/docs/runtime.md
@@ -64,6 +64,26 @@ pyapp's conditions that axe resolves at *build* time instead of runtime:
 | Project embedded / dependency file / single project | project + dependency wheels always embedded |
 | Management enabled | always enabled as `self` |
 
+### Differences from PyInstaller
+
+PyInstaller *freezes* an application: its bootloader unpacks a bundle of
+modules collected by static import analysis and runs them inside an embedded
+interpreter. Axe *installs* one: real wheels into a real venv with a full
+CPython, once. That leads to very different runtime behavior:
+
+| PyInstaller (onefile) | axe |
+| --- | --- |
+| Extracts to a fresh temp dir (`_MEIPASS`) on every run, deleted on exit | Unpacks once into a persistent per-app install; every later run is a marker check + exec |
+| App runs inside the bootloader process with `sys.frozen` set | Process is replaced with a normal venv Python; only `AXE=1` marks the install |
+| Modules collected by static import analysis; dynamic imports and data files need hooks/hidden-import hints | Dependencies installed as complete wheels; dynamic imports, package data, `importlib.metadata`, and entry points work as in any venv |
+| `sys.executable` is the frozen binary, so subprocesses that re-invoke Python need special handling (e.g. `multiprocessing.freeze_support`) | `sys.executable` is a real interpreter on disk; subprocesses behave normally |
+| Startup pays the extraction cost every run | Only the first run pays it |
+| No install to manage or clean up beyond temp-dir residue | `self remove` / `restore` / `update` manage the cached install |
+
+The trade-off is size and footprint: axe binaries embed a complete CPython
+and every wheel (~45–60 MB) and leave a cached installation on disk, where
+PyInstaller prunes to just what the app imports.
+
 ## Execution
 
 Projects are executed using `execve` on non-Windows systems, replacing the

--- a/runtime/env_test.go
+++ b/runtime/env_test.go
@@ -25,6 +25,18 @@ func TestIsolatedEnv(t *testing.T) {
 	}
 }
 
+func TestAppEnvDropsInheritedAXE(t *testing.T) {
+	env := appEnv([]string{"AXE=0", "axe=no", "PATH=/usr/bin"})
+	if !slices.Contains(env, "AXE=1") {
+		t.Errorf("missing AXE=1 in %v", env)
+	}
+	for _, kv := range []string{"AXE=0", "axe=no"} {
+		if slices.Contains(env, kv) {
+			t.Errorf("inherited %s survived: %v", kv, env)
+		}
+	}
+}
+
 func TestInstallerEnv(t *testing.T) {
 	env := installerEnv([]string{
 		"PATH=/usr/bin",

--- a/runtime/env_test.go
+++ b/runtime/env_test.go
@@ -1,0 +1,56 @@
+package main
+
+import (
+	"slices"
+	"testing"
+)
+
+func TestIsolatedEnv(t *testing.T) {
+	env := isolatedEnv([]string{
+		"PATH=/usr/bin",
+		"PYTHONPATH=/home/user/hacks",
+		"PYTHONHOME=/opt/py",
+		"pythonstartup=/home/user/startup.py",
+		"HOME=/home/user",
+	})
+	for _, kv := range []string{"PATH=/usr/bin", "HOME=/home/user", "PYTHONNOUSERSITE=1", "PYTHONSAFEPATH=1"} {
+		if !slices.Contains(env, kv) {
+			t.Errorf("missing %s in %v", kv, env)
+		}
+	}
+	for _, kv := range []string{"PYTHONPATH=/home/user/hacks", "PYTHONHOME=/opt/py", "pythonstartup=/home/user/startup.py"} {
+		if slices.Contains(env, kv) {
+			t.Errorf("user variable %s survived isolation: %v", kv, env)
+		}
+	}
+}
+
+func TestInstallerEnv(t *testing.T) {
+	env := installerEnv([]string{
+		"PATH=/usr/bin",
+		"UV_INDEX_URL=https://example.com/simple",
+		"UV_PYTHON=3.9",
+		"PIP_INDEX_URL=https://example.com/simple",
+		"PYTHONPATH=/home/user/hacks",
+		"VIRTUAL_ENV=/home/user/.venv",
+		"CONDA_PREFIX=/opt/conda",
+		"HOME=/home/user",
+	})
+	for _, kv := range []string{"PATH=/usr/bin", "HOME=/home/user", "UV_NO_CONFIG=1", "UV_OFFLINE=1"} {
+		if !slices.Contains(env, kv) {
+			t.Errorf("missing %s in %v", kv, env)
+		}
+	}
+	for _, kv := range []string{
+		"UV_INDEX_URL=https://example.com/simple",
+		"UV_PYTHON=3.9",
+		"PIP_INDEX_URL=https://example.com/simple",
+		"PYTHONPATH=/home/user/hacks",
+		"VIRTUAL_ENV=/home/user/.venv",
+		"CONDA_PREFIX=/opt/conda",
+	} {
+		if slices.Contains(env, kv) {
+			t.Errorf("user variable %s survived isolation: %v", kv, env)
+		}
+	}
+}

--- a/runtime/execute.go
+++ b/runtime/execute.go
@@ -25,6 +25,23 @@ func appCommand(c *config, install string, args []string) ([]string, error) {
 	return nil, fmt.Errorf("unknown entrypoint kind %q", c.Entrypoint.Kind)
 }
 
+// isolatedEnv replicates `python -I` for entrypoints the interpreter flag
+// cannot reach (console scripts run the venv python via their shebang):
+// every PYTHON* variable is dropped (-E), then user site-packages and
+// script-dir sys.path prepending are disabled (-s, -P). Module and spec
+// entrypoints pass -I too, which subsumes all of this.
+func isolatedEnv(env []string) []string {
+	out := make([]string, 0, len(env)+2)
+	for _, kv := range env {
+		key, _, _ := strings.Cut(kv, "=")
+		if strings.HasPrefix(strings.ToUpper(key), "PYTHON") {
+			continue
+		}
+		out = append(out, kv)
+	}
+	return append(out, "PYTHONNOUSERSITE=1", "PYTHONSAFEPATH=1")
+}
+
 // executeApp hands control to the application: process replacement on
 // non-Windows (see exec_unix.go), child process with exit-code forwarding on
 // Windows (see exec_windows.go). AXE=1 lets apps detect this install mode.
@@ -33,7 +50,7 @@ func executeApp(c *config, install string, args []string) error {
 	if err != nil {
 		return err
 	}
-	env := append(os.Environ(), "AXE=1")
+	env := append(isolatedEnv(os.Environ()), "AXE=1")
 	debugf("executing: %v", argv)
 	return execProcess(argv, env)
 }

--- a/runtime/execute.go
+++ b/runtime/execute.go
@@ -3,6 +3,7 @@ package main
 import (
 	"fmt"
 	"os"
+	"slices"
 	"strings"
 )
 
@@ -42,6 +43,17 @@ func isolatedEnv(env []string) []string {
 	return append(out, "PYTHONNOUSERSITE=1", "PYTHONSAFEPATH=1")
 }
 
+// appEnv is the environment handed to the application: Python isolation
+// plus the canonical AXE=1 marker. Any inherited AXE value is dropped first —
+// duplicate entries would let a user-set AXE=0 win on some platforms.
+func appEnv(env []string) []string {
+	out := slices.DeleteFunc(isolatedEnv(env), func(kv string) bool {
+		key, _, _ := strings.Cut(kv, "=")
+		return strings.EqualFold(key, "AXE")
+	})
+	return append(out, "AXE=1")
+}
+
 // executeApp hands control to the application: process replacement on
 // non-Windows (see exec_unix.go), child process with exit-code forwarding on
 // Windows (see exec_windows.go). AXE=1 lets apps detect this install mode.
@@ -50,7 +62,7 @@ func executeApp(c *config, install string, args []string) error {
 	if err != nil {
 		return err
 	}
-	env := append(isolatedEnv(os.Environ()), "AXE=1")
+	env := appEnv(os.Environ())
 	debugf("executing: %v", argv)
 	return execProcess(argv, env)
 }

--- a/runtime/install.go
+++ b/runtime/install.go
@@ -118,17 +118,34 @@ func extractWheels(p *payload, dest string) error {
 	return nil
 }
 
-// runUV runs uv with user configuration disabled so behavior is identical on
-// every machine.
+// installerEnv is the uv analogue of `pip --isolated`: every variable that
+// could steer uv or the embedded Python is dropped, so the bootstrap behaves
+// identically on every machine. UV_OFFLINE guarantees uv can never reach for
+// the network, even for operations where we don't pass --offline explicitly.
+func installerEnv(env []string) []string {
+	out := make([]string, 0, len(env)+2)
+	for _, kv := range env {
+		key, _, _ := strings.Cut(kv, "=")
+		upper := strings.ToUpper(key)
+		if strings.HasPrefix(upper, "UV_") || strings.HasPrefix(upper, "PIP_") ||
+			strings.HasPrefix(upper, "PYTHON") ||
+			upper == "VIRTUAL_ENV" || upper == "CONDA_PREFIX" {
+			continue
+		}
+		out = append(out, kv)
+	}
+	return append(out, "UV_NO_CONFIG=1", "UV_OFFLINE=1")
+}
+
+// runUV runs uv with user configuration and environment influence disabled
+// so behavior is identical on every machine.
 func runUV(uv string, args ...string) error {
 	if os.Getenv("AXE_DEBUG") == "" {
 		args = append(args, "--quiet")
 	}
 	debugf("running: %s %v", uv, args)
 	cmd := exec.Command(uv, args...)
-	// UV_OFFLINE guarantees uv can never reach for the network, even for
-	// operations where we don't pass --offline explicitly.
-	cmd.Env = append(os.Environ(), "UV_NO_CONFIG=1", "UV_OFFLINE=1")
+	cmd.Env = installerEnv(os.Environ())
 	cmd.Stdout = os.Stderr
 	cmd.Stderr = os.Stderr
 	return cmd.Run()

--- a/runtime/trailer.go
+++ b/runtime/trailer.go
@@ -14,6 +14,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"slices"
 	"strings"
 )
 
@@ -86,7 +87,8 @@ func (p *payload) configBytes() ([]byte, error) {
 	return p.readAll("config.json")
 }
 
-// wheelNames lists the payload's wheels/ entries.
+// wheelNames lists the payload's wheels/ entries, sorted so extraction order
+// never depends on how the payload was assembled.
 func (p *payload) wheelNames() []string {
 	var names []string
 	for _, f := range p.zip.File {
@@ -94,5 +96,6 @@ func (p *payload) wheelNames() []string {
 			names = append(names, f.Name)
 		}
 	}
+	slices.Sort(names)
 	return names
 }


### PR DESCRIPTION
Audit of the Go runtime against [pyapp's runtime behavior](https://ofek.dev/pyapp/latest/runtime/) found two gaps in the "consistent behavior on each user's machine" guarantees; this closes both and documents the runtime flow.

## Changes

- **Isolated mode for console-script entrypoints** (`runtime/execute.go`): pyapp runs everything under `python -I`. Axe did too for `module`/`spec` entrypoints, but the default `script` kind ran the venv console script via its shebang, inheriting the user's `PYTHONPATH`, `PYTHONHOME`, and user site-packages. The app environment now strips all `PYTHON*` variables and sets `PYTHONNOUSERSITE`/`PYTHONSAFEPATH` — the env equivalent of `-I`, which also covers Windows `.exe` script wrappers.
- **Installer isolation** (`runtime/install.go`): pyapp installs with pip `--isolated`, ignoring config *and* environment. Axe set `UV_NO_CONFIG`/`UV_OFFLINE` but still let `UV_*`, `PIP_*`, `PYTHON*`, `VIRTUAL_ENV`, and `CONDA_PREFIX` steer uv during bootstrap; those are now dropped.
- **Deterministic wheel order** (`runtime/trailer.go`): `wheelNames()` is now sorted, so install order never depends on payload assembly order. Also fixes a pre-existing map-ordering flake in `TestPayloadRoundTrip`.
- **Docs**: new `docs/runtime.md` mirroring pyapp's runtime-behavior page — adapted mermaid flowchart, a table of which pyapp runtime conditions axe resolves at build time instead, and the execution guarantees. Linked from the README; CHANGELOG entry under Unreleased.

pyapp's network-dependent branches (distribution/uv/pip download, source caching, dependency files, full isolation) are intentionally absent: axe resolves them at build time because everything is embedded — the table in `docs/runtime.md` spells out the mapping.

## Verification

- `uv run pytest -q`: 48 passed (includes offline e2e with rebuilt stubs)
- `cd runtime && rtk go test ./...`: 18 passed (`go test -count=5` confirms the flake fix); new `env_test.go` covers both env filters
- Hostile-environment check: built the cowsay example and ran its first run with `PYTHONPATH` pointing at a `six.py` that raises (cowsay imports `six`, so any leak crashes), `PYTHONHOME=/nonexistent`, and garbage `UV_INDEX_URL`/`UV_PYTHON`/`UV_LINK_MODE`/`PIP_INDEX_URL`/`VIRTUAL_ENV` — bootstrap and execution both succeeded

🤖 Generated with [Claude Code](https://claude.com/claude-code)