### PR TITLE
Collapse bootstrap status into a single [axe]-prefixed line

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,8 +32,7 @@ Hand the binary to anyone — nothing to install, nothing to download:
 
 ```console
 $ ./dist/bin/mycli-0.1.0-darwin-arm64
-setting up mycli 0.1.0 (first run)...
-done.
+[axe] bootstrapping mycli 0.1.0...
 Hello from mycli!
 
 $ ./dist/bin/mycli-0.1.0-darwin-arm64   # instant from now on

--- a/runtime/install.go
+++ b/runtime/install.go
@@ -49,11 +49,10 @@ func ensureInstalled(c *config, p *payload) (string, error) {
 		return install, nil
 	}
 
-	statusf("setting up %s %s (first run)...", c.Name, c.Version)
+	statusf("[axe] bootstrapping %s %s...", c.Name, c.Version)
 	if err := bootstrap(c, p, install); err != nil {
 		return "", err
 	}
-	statusf("done.")
 	return install, nil
 }
 

--- a/tests/test_e2e.py
+++ b/tests/test_e2e.py
@@ -77,7 +77,7 @@ def test_binary_lifecycle_offline(binary: Path, offline_env: dict[str, str]):
     result = run(binary, ["hello", "world"], offline_env)
     assert result.returncode == 0, result.stderr
     assert "< hello world >" in result.stdout
-    assert "first run" in result.stderr
+    assert "bootstrapping" in result.stderr
     # The app can detect it's running from an axe binary (AXE=1), and its
     # dependency (six) was importable, or the run would have crashed.
     assert "(running from an axe binary)" in result.stderr
@@ -90,7 +90,7 @@ def test_binary_lifecycle_offline(binary: Path, offline_env: dict[str, str]):
     result = run(binary, ["again"], offline_env, timeout=60)
     assert result.returncode == 0, result.stderr
     assert "< again >" in result.stdout
-    assert "first run" not in result.stderr
+    assert "bootstrapping" not in result.stderr
 
     result = run(binary, ["self", "python-path"], offline_env, timeout=60)
     assert result.returncode == 0, result.stderr
@@ -124,14 +124,14 @@ def test_self_commands_offline(binary: Path, offline_env: dict[str, str]):
     result = run(binary, ["moo"], offline_env)
     assert result.returncode == 0, result.stderr
     assert "< moo >" in result.stdout
-    assert "first run" in result.stderr
+    assert "bootstrapping" in result.stderr
 
     # restore reinstalls in one step.
     result = run(binary, ["self", "restore"], offline_env)
     assert result.returncode == 0, result.stderr
     result = run(binary, ["back"], offline_env, timeout=60)
     assert result.returncode == 0, result.stderr
-    assert "first run" not in result.stderr
+    assert "bootstrapping" not in result.stderr
 
 
 def test_interrupted_bootstrap_recovers(binary: Path, offline_env: dict[str, str], tmp_path):
@@ -145,7 +145,7 @@ def test_interrupted_bootstrap_recovers(binary: Path, offline_env: dict[str, str
     (install / ".axe-installed").unlink()
     result = run(binary, ["rebuilt"], env)
     assert result.returncode == 0, result.stderr
-    assert "first run" in result.stderr
+    assert "bootstrapping" in result.stderr
     assert "< rebuilt >" in result.stdout
 
 


### PR DESCRIPTION
The first-run bootstrap printed two lines:

```
setting up mycli 0.1.0 (first run)...
done.
```

Now it prints one:

```
[axe] bootstrapping mycli 0.1.0...
```

- The message goes to stderr as before (`statusf` already targeted stderr), keeping the app's stdout clean.
- The trailing `done.` line is removed.
- Test assertions updated from `"first run"` to `"bootstrapping"`, and the README sample output refreshed.
- No version bump.

Stubs rebuilt locally and the full suite passes (48 passed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)