### PR TITLE
feat: make the reserved self command group optional

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,9 @@
 
 ### Enhancements
 
-- Make the reserved `self` command group optional: build with
-  `AXE_ENABLE_SELF_COMMAND_GROUP=false` and the binary passes `self` to the
-  app like any other argument (for CLIs that have their own `self`
+- Make the reserved `self` command group optional: set
+  `self-command-group = false` in `[tool.axe]` and the binary passes `self`
+  to the app like any other argument (for CLIs that have their own `self`
   subcommand). Combining it with `expose` is a configuration error
 
 ## 0.3.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## Unreleased
+
+### Enhancements
+
+- Make the reserved `self` command group optional: build with
+  `AXE_ENABLE_SELF_COMMAND_GROUP=false` and the binary passes `self` to the
+  app like any other argument (for CLIs that have their own `self`
+  subcommand). Combining it with `expose` is a configuration error
+
 ## 0.3.0
 
 ### Behavior changes

--- a/README.md
+++ b/README.md
@@ -105,6 +105,7 @@ uv-version = "0.10.6"         # uv embedded into the binary
 python-release = "20260623"   # python-build-standalone release tag
 expose = ["metadata"]         # extra `self` commands: python, python-path,
                               # cache, metadata — or "all"
+self-command-group = true     # false: don't reserve `self` at all
 ```
 
 ## CLI
@@ -132,9 +133,9 @@ $ myapp self restore   # wipe and reinstall
 $ myapp self update    # reinstall from the embedded payload
 ```
 
-If your CLI needs `self` for itself, build with
-`AXE_ENABLE_SELF_COMMAND_GROUP=false` and the binary reserves nothing —
-`self` reaches your app like any other argument.
+If your CLI needs `self` for itself, set `self-command-group = false` in
+`[tool.axe]` and the binary reserves nothing — `self` reaches your app like
+any other argument.
 
 `AXE=1` is set in your app's environment so it can detect axe installs, and
 `AXE_DEBUG=1` makes the stub verbose.

--- a/README.md
+++ b/README.md
@@ -132,6 +132,10 @@ $ myapp self restore   # wipe and reinstall
 $ myapp self update    # reinstall from the embedded payload
 ```
 
+If your CLI needs `self` for itself, build with
+`AXE_ENABLE_SELF_COMMAND_GROUP=false` and the binary reserves nothing —
+`self` reaches your app like any other argument.
+
 `AXE=1` is set in your app's environment so it can detect axe installs, and
 `AXE_DEBUG=1` makes the stub verbose.
 

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -38,10 +38,7 @@ For each target platform, `axe build`:
 
 All downloads are checksum-verified and cached on the build machine, so
 builds after the first take seconds. Configuration comes from
-`pyproject.toml` — see the [configuration reference](configuration.md) —
-plus one environment variable:
-[`AXE_ENABLE_SELF_COMMAND_GROUP=false`](configuration.md#axe_enable_self_command_group)
-builds binaries without the reserved `self` command group.
+`pyproject.toml` — see the [configuration reference](configuration.md).
 
 Output files are named `<name>-<version>-<os>-<arch>` (plus `.exe` on
 Windows), e.g. `mycli-0.1.0-linux-amd64`.

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -38,7 +38,10 @@ For each target platform, `axe build`:
 
 All downloads are checksum-verified and cached on the build machine, so
 builds after the first take seconds. Configuration comes from
-`pyproject.toml` — see the [configuration reference](configuration.md).
+`pyproject.toml` — see the [configuration reference](configuration.md) —
+plus one environment variable:
+[`AXE_ENABLE_SELF_COMMAND_GROUP=false`](configuration.md#axe_enable_self_command_group)
+builds binaries without the reserved `self` command group.
 
 Output files are named `<name>-<version>-<os>-<arch>` (plus `.exe` on
 Windows), e.g. `mycli-0.1.0-linux-amd64`.

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -11,6 +11,7 @@ python = "3.12"               # default: lower bound of requires-python
 uv-version = "0.10.6"         # uv embedded into the binary
 python-release = "20260623"   # python-build-standalone release tag
 expose = ["metadata"]         # extra `self` commands, or "all"
+self-command-group = true     # false: don't reserve `self` at all
 ```
 
 ## Required `[project]` metadata
@@ -82,17 +83,14 @@ or the string `"all"` for all four. See the
 
 **Default:** none — a minimal management surface for end users.
 
-## `AXE_ENABLE_SELF_COMMAND_GROUP`
+## `self-command-group`
 
-One build-time setting lives in the environment rather than
-`pyproject.toml`: set `AXE_ENABLE_SELF_COMMAND_GROUP=false` when running
-`axe build` and the binaries won't reserve the `self` command group at all —
-`myapp self …` is passed to your app like any other arguments. Use it when
-your CLI has its own `self` subcommand.
+Set to `false` and built binaries won't reserve the `self` command group at
+all — `myapp self …` is passed to your app like any other arguments. Use it
+when your CLI has its own `self` subcommand.
 
-Accepted values: `true`/`false`, `1`/`0`, `yes`/`no`, `on`/`off`
-(case-insensitive). Combining `false` with `expose` is a configuration
-error, since the exposed commands would be unreachable.
+Combining `false` with `expose` is a configuration error, since the exposed
+commands would be unreachable.
 
 **Default:** `true` — binaries get `self remove`, `self restore`, and
 `self update`. Without them, the only way to manage an installation is

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -81,3 +81,19 @@ or the string `"all"` for all four. See the
 [runtime reference](runtime.md#self-commands) for what each command does.
 
 **Default:** none — a minimal management surface for end users.
+
+## `AXE_ENABLE_SELF_COMMAND_GROUP`
+
+One build-time setting lives in the environment rather than
+`pyproject.toml`: set `AXE_ENABLE_SELF_COMMAND_GROUP=false` when running
+`axe build` and the binaries won't reserve the `self` command group at all —
+`myapp self …` is passed to your app like any other arguments. Use it when
+your CLI has its own `self` subcommand.
+
+Accepted values: `true`/`false`, `1`/`0`, `yes`/`no`, `on`/`off`
+(case-insensitive). Combining `false` with `expose` is a configuration
+error, since the exposed commands would be unreachable.
+
+**Default:** `true` — binaries get `self remove`, `self restore`, and
+`self update`. Without them, the only way to manage an installation is
+deleting its [install directory](runtime.md#install-locations) by hand.

--- a/docs/reference/runtime.md
+++ b/docs/reference/runtime.md
@@ -10,7 +10,7 @@ see [runtime internals](../runtime.md).
 Built binaries reserve exactly one command group, `self`; every other
 invocation is passed untouched to your app. (Even that reservation is
 optional: building with
-[`AXE_ENABLE_SELF_COMMAND_GROUP=false`](configuration.md#axe_enable_self_command_group)
+[`self-command-group = false`](configuration.md#self-command-group)
 produces binaries with no `self` group at all.)
 
 Always available:

--- a/docs/reference/runtime.md
+++ b/docs/reference/runtime.md
@@ -8,7 +8,10 @@ see [runtime internals](../runtime.md).
 ## `self` commands
 
 Built binaries reserve exactly one command group, `self`; every other
-invocation is passed untouched to your app.
+invocation is passed untouched to your app. (Even that reservation is
+optional: building with
+[`AXE_ENABLE_SELF_COMMAND_GROUP=false`](configuration.md#axe_enable_self_command_group)
+produces binaries with no `self` group at all.)
 
 Always available:
 

--- a/docs/runtime.md
+++ b/docs/runtime.md
@@ -50,6 +50,8 @@ Step by step:
 - **Execute / manage** — `self` is the reserved management command group
   (`remove`, `restore`, `update` always; `python`, `python-path`, `cache`,
   `metadata` when exposed at build time); everything else goes to the app.
+  Building with `AXE_ENABLE_SELF_COMMAND_GROUP=false` drops the reservation
+  entirely, so `self` reaches the app too.
 
 ### Differences from pyapp
 

--- a/docs/runtime.md
+++ b/docs/runtime.md
@@ -50,8 +50,8 @@ Step by step:
 - **Execute / manage** — `self` is the reserved management command group
   (`remove`, `restore`, `update` always; `python`, `python-path`, `cache`,
   `metadata` when exposed at build time); everything else goes to the app.
-  Building with `AXE_ENABLE_SELF_COMMAND_GROUP=false` drops the reservation
-  entirely, so `self` reaches the app too.
+  Building with `self-command-group = false` drops the reservation entirely,
+  so `self` reaches the app too.
 
 ### Differences from pyapp
 

--- a/runtime/config.go
+++ b/runtime/config.go
@@ -21,10 +21,13 @@ type config struct {
 	PythonVersion string     `json:"python_version"`
 	UVVersion     string     `json:"uv_version"`
 	Expose        []string   `json:"expose"`
-	Fingerprint   string     `json:"fingerprint"`
-	WheelName     string     `json:"wheel_name"`
-	UVArchive     string     `json:"uv_archive"`
-	PythonArchive string     `json:"python_archive"`
+	// nil means enabled: configs written before this key existed keep the
+	// reserved `self` group.
+	SelfCommandGroup *bool  `json:"self_command_group"`
+	Fingerprint      string `json:"fingerprint"`
+	WheelName        string `json:"wheel_name"`
+	UVArchive        string `json:"uv_archive"`
+	PythonArchive    string `json:"python_archive"`
 }
 
 func parseConfig(data []byte) (*config, error) {
@@ -52,4 +55,8 @@ func parseConfig(data []byte) (*config, error) {
 
 func (c *config) exposed(command string) bool {
 	return slices.Contains(c.Expose, command)
+}
+
+func (c *config) selfEnabled() bool {
+	return c.SelfCommandGroup == nil || *c.SelfCommandGroup
 }

--- a/runtime/config_test.go
+++ b/runtime/config_test.go
@@ -35,6 +35,26 @@ func TestParseConfig(t *testing.T) {
 	}
 }
 
+func TestSelfEnabled(t *testing.T) {
+	c, err := parseConfig([]byte(validConfig))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !c.selfEnabled() {
+		t.Error("self command group should default to enabled when the key is absent")
+	}
+
+	disabled := strings.Replace(validConfig, `"expose": ["python-path"],`,
+		`"expose": [], "self_command_group": false,`, 1)
+	c, err = parseConfig([]byte(disabled))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if c.selfEnabled() {
+		t.Error("self command group should be disabled when the key is false")
+	}
+}
+
 func TestParseConfigMissingField(t *testing.T) {
 	broken := strings.Replace(validConfig, `"fingerprint": "abcdef0123456789",`, "", 1)
 	if _, err := parseConfig([]byte(broken)); err == nil {

--- a/runtime/main.go
+++ b/runtime/main.go
@@ -25,7 +25,7 @@ func main() {
 	}
 
 	args := os.Args[1:]
-	if len(args) > 0 && args[0] == "self" {
+	if len(args) > 0 && args[0] == "self" && c.selfEnabled() {
 		if err := runSelf(c, p, args[1:]); err != nil {
 			fatalf("%v", err)
 		}

--- a/src/axe/config.py
+++ b/src/axe/config.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import os
 import re
 import tomllib
 from dataclasses import dataclass, field
@@ -34,6 +35,7 @@ class BuildConfig:
     uv_version: str = DEFAULT_UV_VERSION
     python_release: str = DEFAULT_PYTHON_RELEASE
     expose: list[str] = field(default_factory=list)
+    self_command_group: bool = True
 
     def runtime_config(self, resolved_python: str) -> dict:
         """The JSON document embedded in built binaries; payload.compose adds
@@ -45,6 +47,7 @@ class BuildConfig:
             "python_version": resolved_python,
             "uv_version": self.uv_version,
             "expose": self.expose,
+            "self_command_group": self.self_command_group,
         }
 
 
@@ -68,6 +71,20 @@ def python_from_requires(requires_python: str) -> str | None:
         if m:
             return m.group(2).removesuffix(".*")
     return None
+
+
+def self_command_group_enabled() -> bool:
+    """Whether built binaries reserve the `self` command group, controlled by
+    the AXE_ENABLE_SELF_COMMAND_GROUP build-time environment variable."""
+    value = os.environ.get("AXE_ENABLE_SELF_COMMAND_GROUP")
+    if value is None:
+        return True
+    normalized = value.strip().lower()
+    if normalized in ("1", "true", "yes", "on"):
+        return True
+    if normalized in ("0", "false", "no", "off"):
+        return False
+    raise ConfigError(f"AXE_ENABLE_SELF_COMMAND_GROUP must be true or false, got {value!r}")
 
 
 def load_config(project_dir: Path) -> BuildConfig:
@@ -121,6 +138,13 @@ def load_config(project_dir: Path) -> BuildConfig:
                 f"unknown expose command {command!r}; valid: {', '.join(EXPOSABLE_COMMANDS)}"
             )
 
+    self_command_group = self_command_group_enabled()
+    if not self_command_group and expose:
+        raise ConfigError(
+            "expose requires the self command group; unset "
+            "AXE_ENABLE_SELF_COMMAND_GROUP or remove expose from [tool.axe]"
+        )
+
     return BuildConfig(
         name=name,
         version=str(version),
@@ -129,4 +153,5 @@ def load_config(project_dir: Path) -> BuildConfig:
         uv_version=str(axe.get("uv-version", DEFAULT_UV_VERSION)),
         python_release=str(axe.get("python-release", DEFAULT_PYTHON_RELEASE)),
         expose=list(expose),
+        self_command_group=self_command_group,
     )

--- a/src/axe/config.py
+++ b/src/axe/config.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import os
 import re
 import tomllib
 from dataclasses import dataclass, field
@@ -73,20 +72,6 @@ def python_from_requires(requires_python: str) -> str | None:
     return None
 
 
-def self_command_group_enabled() -> bool:
-    """Whether built binaries reserve the `self` command group, controlled by
-    the AXE_ENABLE_SELF_COMMAND_GROUP build-time environment variable."""
-    value = os.environ.get("AXE_ENABLE_SELF_COMMAND_GROUP")
-    if value is None:
-        return True
-    normalized = value.strip().lower()
-    if normalized in ("1", "true", "yes", "on"):
-        return True
-    if normalized in ("0", "false", "no", "off"):
-        return False
-    raise ConfigError(f"AXE_ENABLE_SELF_COMMAND_GROUP must be true or false, got {value!r}")
-
-
 def load_config(project_dir: Path) -> BuildConfig:
     pyproject = project_dir / "pyproject.toml"
     if not pyproject.is_file():
@@ -138,11 +123,13 @@ def load_config(project_dir: Path) -> BuildConfig:
                 f"unknown expose command {command!r}; valid: {', '.join(EXPOSABLE_COMMANDS)}"
             )
 
-    self_command_group = self_command_group_enabled()
+    self_command_group = axe.get("self-command-group", True)
+    if not isinstance(self_command_group, bool):
+        raise ConfigError("self-command-group must be a boolean")
     if not self_command_group and expose:
         raise ConfigError(
-            "expose requires the self command group; unset "
-            "AXE_ENABLE_SELF_COMMAND_GROUP or remove expose from [tool.axe]"
+            "expose requires the self command group; remove expose or "
+            "re-enable self-command-group in [tool.axe]"
         )
 
     return BuildConfig(

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -124,6 +124,62 @@ def test_missing_pyproject(tmp_path):
         load_config(tmp_path)
 
 
+MINIMAL_PYPROJECT = """
+[project]
+name = "demo"
+version = "0.1.0"
+
+[project.scripts]
+demo = "demo:main"
+"""
+
+
+def test_self_command_group_default(tmp_path):
+    config = load_config(write_pyproject(tmp_path, MINIMAL_PYPROJECT))
+    assert config.self_command_group is True
+    assert config.runtime_config("3.12")["self_command_group"] is True
+
+
+@pytest.mark.parametrize("value", ["false", "FALSE", "0", "no", "off"])
+def test_self_command_group_disabled(tmp_path, monkeypatch, value):
+    monkeypatch.setenv("AXE_ENABLE_SELF_COMMAND_GROUP", value)
+    config = load_config(write_pyproject(tmp_path, MINIMAL_PYPROJECT))
+    assert config.self_command_group is False
+    assert config.runtime_config("3.12")["self_command_group"] is False
+
+
+@pytest.mark.parametrize("value", ["true", "1", "yes", "on"])
+def test_self_command_group_enabled_explicitly(tmp_path, monkeypatch, value):
+    monkeypatch.setenv("AXE_ENABLE_SELF_COMMAND_GROUP", value)
+    config = load_config(write_pyproject(tmp_path, MINIMAL_PYPROJECT))
+    assert config.self_command_group is True
+
+
+def test_self_command_group_bad_value(tmp_path, monkeypatch):
+    monkeypatch.setenv("AXE_ENABLE_SELF_COMMAND_GROUP", "maybe")
+    with pytest.raises(ConfigError, match="AXE_ENABLE_SELF_COMMAND_GROUP"):
+        load_config(write_pyproject(tmp_path, MINIMAL_PYPROJECT))
+
+
+def test_self_command_group_disabled_conflicts_with_expose(tmp_path, monkeypatch):
+    monkeypatch.setenv("AXE_ENABLE_SELF_COMMAND_GROUP", "false")
+    with pytest.raises(ConfigError, match="expose requires the self command group"):
+        load_config(
+            write_pyproject(
+                tmp_path,
+                """
+[project]
+name = "demo"
+version = "0.1.0"
+
+[tool.axe]
+entrypoint = "demo"
+expose = ["metadata"]
+""",
+            )
+        )
+
+
 @pytest.mark.parametrize(
     ("value", "kind", "parsed"),
     [

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -124,45 +124,62 @@ def test_missing_pyproject(tmp_path):
         load_config(tmp_path)
 
 
-MINIMAL_PYPROJECT = """
+def test_self_command_group_default(tmp_path):
+    config = load_config(
+        write_pyproject(
+            tmp_path,
+            """
 [project]
 name = "demo"
 version = "0.1.0"
 
 [project.scripts]
 demo = "demo:main"
-"""
-
-
-def test_self_command_group_default(tmp_path):
-    config = load_config(write_pyproject(tmp_path, MINIMAL_PYPROJECT))
+""",
+        )
+    )
     assert config.self_command_group is True
     assert config.runtime_config("3.12")["self_command_group"] is True
 
 
-@pytest.mark.parametrize("value", ["false", "FALSE", "0", "no", "off"])
-def test_self_command_group_disabled(tmp_path, monkeypatch, value):
-    monkeypatch.setenv("AXE_ENABLE_SELF_COMMAND_GROUP", value)
-    config = load_config(write_pyproject(tmp_path, MINIMAL_PYPROJECT))
+def test_self_command_group_disabled(tmp_path):
+    config = load_config(
+        write_pyproject(
+            tmp_path,
+            """
+[project]
+name = "demo"
+version = "0.1.0"
+
+[tool.axe]
+entrypoint = "demo"
+self-command-group = false
+""",
+        )
+    )
     assert config.self_command_group is False
     assert config.runtime_config("3.12")["self_command_group"] is False
 
 
-@pytest.mark.parametrize("value", ["true", "1", "yes", "on"])
-def test_self_command_group_enabled_explicitly(tmp_path, monkeypatch, value):
-    monkeypatch.setenv("AXE_ENABLE_SELF_COMMAND_GROUP", value)
-    config = load_config(write_pyproject(tmp_path, MINIMAL_PYPROJECT))
-    assert config.self_command_group is True
+def test_self_command_group_bad_value(tmp_path):
+    with pytest.raises(ConfigError, match="self-command-group must be a boolean"):
+        load_config(
+            write_pyproject(
+                tmp_path,
+                """
+[project]
+name = "demo"
+version = "0.1.0"
+
+[tool.axe]
+entrypoint = "demo"
+self-command-group = "no"
+""",
+            )
+        )
 
 
-def test_self_command_group_bad_value(tmp_path, monkeypatch):
-    monkeypatch.setenv("AXE_ENABLE_SELF_COMMAND_GROUP", "maybe")
-    with pytest.raises(ConfigError, match="AXE_ENABLE_SELF_COMMAND_GROUP"):
-        load_config(write_pyproject(tmp_path, MINIMAL_PYPROJECT))
-
-
-def test_self_command_group_disabled_conflicts_with_expose(tmp_path, monkeypatch):
-    monkeypatch.setenv("AXE_ENABLE_SELF_COMMAND_GROUP", "false")
+def test_self_command_group_disabled_conflicts_with_expose(tmp_path):
     with pytest.raises(ConfigError, match="expose requires the self command group"):
         load_config(
             write_pyproject(
@@ -174,6 +191,7 @@ version = "0.1.0"
 
 [tool.axe]
 entrypoint = "demo"
+self-command-group = false
 expose = ["metadata"]
 """,
             )

--- a/tests/test_e2e.py
+++ b/tests/test_e2e.py
@@ -134,18 +134,19 @@ def test_self_commands_offline(binary: Path, offline_env: dict[str, str]):
     assert "bootstrapping" not in result.stderr
 
 
-def test_self_command_group_disabled(tmp_path, offline_env: dict[str, str], monkeypatch):
-    # With AXE_ENABLE_SELF_COMMAND_GROUP=false the binary reserves nothing:
-    # `self` is just another argument for the app. The example exposes self
-    # commands, which conflicts with disabling, so build a copy without them.
+def test_self_command_group_disabled(tmp_path, offline_env: dict[str, str]):
+    # With self-command-group = false the binary reserves nothing: `self` is
+    # just another argument for the app. The example exposes self commands,
+    # which conflicts with disabling, so build a copy with expose replaced.
     project = tmp_path / "cowsay"
     shutil.copytree(COWSAY, project)
     pyproject = project / "pyproject.toml"
     body = pyproject.read_text()
     assert "[tool.axe]" in body
-    pyproject.write_text(body[: body.index("[tool.axe]")])
+    pyproject.write_text(
+        body[: body.index("[tool.axe]")] + "[tool.axe]\nself-command-group = false\n"
+    )
 
-    monkeypatch.setenv("AXE_ENABLE_SELF_COMMAND_GROUP", "false")
     (binary,) = build(project, output_dir=tmp_path / "bin")
 
     env = dict(offline_env, AXE_DATA_DIR=str(tmp_path / "data"))

--- a/tests/test_e2e.py
+++ b/tests/test_e2e.py
@@ -134,6 +134,30 @@ def test_self_commands_offline(binary: Path, offline_env: dict[str, str]):
     assert "bootstrapping" not in result.stderr
 
 
+def test_self_command_group_disabled(tmp_path, offline_env: dict[str, str], monkeypatch):
+    # With AXE_ENABLE_SELF_COMMAND_GROUP=false the binary reserves nothing:
+    # `self` is just another argument for the app. The example exposes self
+    # commands, which conflicts with disabling, so build a copy without them.
+    project = tmp_path / "cowsay"
+    shutil.copytree(COWSAY, project)
+    pyproject = project / "pyproject.toml"
+    body = pyproject.read_text()
+    assert "[tool.axe]" in body
+    pyproject.write_text(body[: body.index("[tool.axe]")])
+
+    monkeypatch.setenv("AXE_ENABLE_SELF_COMMAND_GROUP", "false")
+    (binary,) = build(project, output_dir=tmp_path / "bin")
+
+    env = dict(offline_env, AXE_DATA_DIR=str(tmp_path / "data"))
+    result = run(binary, ["self", "metadata"], env)
+    assert result.returncode == 0, result.stderr
+    assert "< self metadata >" in result.stdout
+
+    result = run(binary, ["self", "remove"], env, timeout=60)
+    assert result.returncode == 0, result.stderr
+    assert "< self remove >" in result.stdout
+
+
 def test_interrupted_bootstrap_recovers(binary: Path, offline_env: dict[str, str], tmp_path):
     # Simulate a crash mid-bootstrap: install dir exists but has no
     # completion marker. The next run must rebuild, not trust the residue.


### PR DESCRIPTION
## Summary

Adds a `[tool.axe]` option to drop the reserved `self` command group from compiled binaries, for CLIs that need `self` as their own subcommand:

```toml
[tool.axe]
self-command-group = false
```

```console
$ myapp self anything   # reaches the app, nothing is reserved
```

## How it works

- `load_config` reads the boolean `self-command-group` key (default `true`; non-boolean values are a `ConfigError`) and bakes it into the embedded config as `self_command_group`.
- The Go stub checks the flag before intercepting `self` in `main.go`; when disabled, all arguments go to the app. An absent key means enabled (`*bool`, nil-safe), so payloads from older axe versions keep their behavior.
- Setting `false` while also exposing extra `self` commands via `expose` is a configuration error, since the exposed commands would be unreachable.
- Default is unchanged: binaries keep `self remove` / `restore` / `update`.

## Testing

- `tests/test_config.py`: default, disabled, non-boolean value, and the expose conflict, plus the embedded-config key.
- `runtime/config_test.go`: `selfEnabled()` defaults to true when the key is absent, false when set.
- `tests/test_e2e.py::test_self_command_group_disabled`: builds a real binary with the option off and verifies `self metadata` / `self remove` render as cowsay output instead of being intercepted.
- Full suite green locally: 53 pytest tests + 20 Go tests, ruff and gofmt clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)