### PR TITLE
feat: support mirrors for uv and python-build-standalone downloads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## Unreleased
+
+### Enhancements
+
+- Add `[tool.axe]` `uv-releases-url` and
+  `python-build-standalone-releases-url` to download the embedded uv and
+  CPython from a mirror instead of github.com (for network-isolated build
+  machines behind a proxy). HTTP Basic credentials for the mirror can be
+  supplied via `UV_RELEASES_USERNAME`/`UV_RELEASES_PASSWORD` and
+  `PYTHON_BUILD_STANDALONE_RELEASES_USERNAME`/`PYTHON_BUILD_STANDALONE_RELEASES_PASSWORD`
+
 ## 0.4.0
 
 ### Enhancements

--- a/README.md
+++ b/README.md
@@ -103,6 +103,8 @@ python = "3.12"               # "3.X" picks the newest 3.X.*; "3.X.Y" pins
                               # default: lower bound of requires-python
 uv-version = "0.10.6"         # uv embedded into the binary
 python-release = "20260623"   # python-build-standalone release tag
+uv-releases-url = "https://mirror.corp/uv"    # download uv from a mirror
+python-build-standalone-releases-url = "https://mirror.corp/pbs"  # ...and CPython
 expose = ["metadata"]         # extra `self` commands: python, python-path,
                               # cache, metadata — or "all"
 self-command-group = true     # false: don't reserve `self` at all

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -53,6 +53,9 @@ resolution, download, or build failures.
 - **Downloads fail or stall behind a corporate proxy** — set
   `UV_NATIVE_TLS=1` so uv uses the system trust store, and run with `-v` to
   see the underlying tool output.
+- **The build machine can't reach github.com at all** — point the uv and
+  CPython downloads at an internal mirror with
+  [`uv-releases-url` and `python-build-standalone-releases-url`](configuration.md#uv-releases-url-and-python-build-standalone-releases-url).
 - **"no entrypoint" / "multiple [project.scripts] entries"** — see
   [entrypoint](configuration.md#entrypoint).
 - **A dependency has no wheel for a target platform** — every dependency

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -10,6 +10,8 @@ entrypoint = "mycli"          # default: the sole [project.scripts] entry
 python = "3.12"               # default: lower bound of requires-python
 uv-version = "0.10.6"         # uv embedded into the binary
 python-release = "20260623"   # python-build-standalone release tag
+uv-releases-url = "https://mirror.corp/uv"    # mirror for uv downloads
+python-build-standalone-releases-url = "https://mirror.corp/pbs"  # ...and CPython
 expose = ["metadata"]         # extra `self` commands, or "all"
 self-command-group = true     # false: don't reserve `self` at all
 ```
@@ -67,6 +69,44 @@ The [python-build-standalone](https://github.com/astral-sh/python-build-standalo
 release tag that provides the embedded CPython.
 
 **Default:** pinned per axe release (currently 20260623).
+
+## `uv-releases-url` and `python-build-standalone-releases-url`
+
+Where `axe build` downloads the uv and CPython
+(python-build-standalone) release artifacts it embeds. Point these at an
+internal mirror when the build machine can't reach github.com — a
+network-isolated environment behind a proxy, an artifact repository like
+Artifactory or Nexus, or a plain file server.
+
+```toml
+[tool.axe]
+uv-releases-url = "https://mirror.corp/astral-sh/uv/releases/download"
+python-build-standalone-releases-url = "https://mirror.corp/astral-sh/python-build-standalone/releases/download"
+```
+
+The mirror must serve the same layout as the GitHub release download URLs;
+axe appends `/<release tag>/<artifact filename>` (plus `.sha256` and
+`SHA256SUMS` checksum files) to the configured base. Downloads stay
+checksum-verified, so a tampered mirror fails the build.
+
+**Defaults:**
+
+- `https://github.com/astral-sh/uv/releases/download`
+- `https://github.com/astral-sh/python-build-standalone/releases/download`
+
+### Mirror credentials
+
+If the mirror requires HTTP Basic authentication, set credentials as
+environment variables on the build machine (never in `pyproject.toml`,
+where they would be committed):
+
+| Variable | Applies to |
+| --- | --- |
+| `UV_RELEASES_USERNAME` / `UV_RELEASES_PASSWORD` | `uv-releases-url` downloads |
+| `PYTHON_BUILD_STANDALONE_RELEASES_USERNAME` / `PYTHON_BUILD_STANDALONE_RELEASES_PASSWORD` | `python-build-standalone-releases-url` downloads |
+
+For token-based mirrors that ignore the username, setting just the
+password variable works (an empty username is sent).
 
 ## `expose`
 

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -86,8 +86,11 @@ python-build-standalone-releases-url = "https://mirror.corp/astral-sh/python-bui
 
 The mirror must serve the same layout as the GitHub release download URLs;
 axe appends `/<release tag>/<artifact filename>` (plus `.sha256` and
-`SHA256SUMS` checksum files) to the configured base. Downloads stay
-checksum-verified, so a tampered mirror fails the build.
+`SHA256SUMS` checksum files) to the configured base. Downloads are still
+checksum-verified, but the checksums come from the same mirror as the
+artifacts, so this catches corruption and incomplete mirroring — it cannot
+detect a malicious mirror that serves matching tampered artifacts and
+checksum files. Only point axe at a mirror you trust as much as github.com.
 
 **Defaults:**
 

--- a/src/axe/build.py
+++ b/src/axe/build.py
@@ -96,10 +96,16 @@ def build(
         for (goos, goarch), stub in stubs.items():
             target = f"{goos}/{goarch}"
             python_version, python_artifact = resolve_python(
-                config.python_version, config.python_release, goos, goarch
+                config.python_version,
+                config.python_release,
+                goos,
+                goarch,
+                config.python_build_standalone_releases_url,
             )
-            python_path = fetch_python(python_artifact, config.python_release)
-            uv_path = fetch_uv(config.uv_version, goos, goarch)
+            python_path = fetch_python(
+                python_artifact, config.python_release, config.python_build_standalone_releases_url
+            )
+            uv_path = fetch_uv(config.uv_version, goos, goarch, config.uv_releases_url)
 
             output.progress(f"{target}: resolving dependencies...")
             requirements = compile_requirements(uv, project_dir, goos, goarch, python_version)

--- a/src/axe/config.py
+++ b/src/axe/config.py
@@ -8,6 +8,7 @@ from dataclasses import dataclass, field
 from pathlib import Path
 
 from . import DEFAULT_PYTHON_RELEASE, DEFAULT_PYTHON_VERSION, DEFAULT_UV_VERSION
+from .fetch import PBS_RELEASES, UV_RELEASES
 
 EXPOSABLE_COMMANDS = ("python", "python-path", "cache", "metadata")
 
@@ -33,6 +34,8 @@ class BuildConfig:
     python_version: str
     uv_version: str = DEFAULT_UV_VERSION
     python_release: str = DEFAULT_PYTHON_RELEASE
+    uv_releases_url: str = UV_RELEASES
+    python_build_standalone_releases_url: str = PBS_RELEASES
     expose: list[str] = field(default_factory=list)
     self_command_group: bool = True
 
@@ -139,6 +142,10 @@ def load_config(project_dir: Path) -> BuildConfig:
         python_version=python_version,
         uv_version=str(axe.get("uv-version", DEFAULT_UV_VERSION)),
         python_release=str(axe.get("python-release", DEFAULT_PYTHON_RELEASE)),
+        uv_releases_url=str(axe.get("uv-releases-url", UV_RELEASES)).rstrip("/"),
+        python_build_standalone_releases_url=str(
+            axe.get("python-build-standalone-releases-url", PBS_RELEASES)
+        ).rstrip("/"),
         expose=list(expose),
         self_command_group=self_command_group,
     )

--- a/src/axe/fetch.py
+++ b/src/axe/fetch.py
@@ -10,6 +10,7 @@ so end users never touch the network. Cache layout:
 
 from __future__ import annotations
 
+import base64
 import hashlib
 import os
 import re
@@ -25,12 +26,27 @@ from .platforms import target_triple
 # black-holing proxy surfaces as an error rather than an apparent hang.
 FETCH_TIMEOUT = 60
 
+# Default release download locations; overridable per project via
+# [tool.axe] uv-releases-url / python-build-standalone-releases-url
+# (mirrors for network-isolated environments).
 UV_RELEASES = "https://github.com/astral-sh/uv/releases/download"
 PBS_RELEASES = "https://github.com/astral-sh/python-build-standalone/releases/download"
 
 
 class FetchError(Exception):
     pass
+
+
+def _auth_header(env_prefix: str) -> str | None:
+    """HTTP Basic credentials for a release mirror, from <PREFIX>_USERNAME /
+    <PREFIX>_PASSWORD. Env vars rather than pyproject.toml keys so secrets
+    never end up committed."""
+    username = os.environ.get(f"{env_prefix}_USERNAME", "")
+    password = os.environ.get(f"{env_prefix}_PASSWORD", "")
+    if not username and not password:
+        return None
+    token = base64.b64encode(f"{username}:{password}".encode()).decode()
+    return f"Basic {token}"
 
 
 def cache_dir() -> Path:
@@ -45,26 +61,29 @@ def cache_dir() -> Path:
     return Path(os.environ.get("XDG_CACHE_HOME", str(Path.home() / ".cache"))) / "axe"
 
 
-def fetch_url(url: str) -> bytes:
+def fetch_url(url: str, auth: str | None = None) -> bytes:
     if output.verbose():
         output.progress(f"GET {url}")
+    request = urllib.request.Request(url)
+    if auth:
+        request.add_header("Authorization", auth)
     try:
-        with urllib.request.urlopen(url, timeout=FETCH_TIMEOUT) as resp:
+        with urllib.request.urlopen(request, timeout=FETCH_TIMEOUT) as resp:
             return resp.read()
     except TimeoutError:
         raise FetchError(
             f"timed out fetching {url} (no data for {FETCH_TIMEOUT}s) — "
-            "check network/proxy connectivity to github.com"
+            "check network/proxy connectivity to the release host"
         ) from None
     except urllib.error.URLError as e:
         raise FetchError(f"failed to fetch {url}: {e}") from None
 
 
-def _fetch_verified(url: str, dest: Path, sha256: str | None) -> Path:
+def _fetch_verified(url: str, dest: Path, sha256: str | None, auth: str | None = None) -> Path:
     if dest.is_file():
         return dest
     output.progress(f"fetching {url.rsplit('/', 1)[-1]}...")
-    data = fetch_url(url)
+    data = fetch_url(url, auth)
     if sha256 and hashlib.sha256(data).hexdigest() != sha256:
         raise FetchError(f"checksum mismatch for {url}")
     dest.parent.mkdir(parents=True, exist_ok=True)
@@ -79,17 +98,19 @@ def uv_artifact_name(uv_version: str, goos: str, goarch: str) -> str:
     return f"uv-{target_triple(goos, goarch)}{ext}"
 
 
-def fetch_uv(uv_version: str, goos: str, goarch: str) -> Path:
+def fetch_uv(uv_version: str, goos: str, goarch: str, releases_url: str = UV_RELEASES) -> Path:
     name = uv_artifact_name(uv_version, goos, goarch)
-    url = f"{UV_RELEASES}/{uv_version}/{name}"
-    sha256 = fetch_url(url + ".sha256").split()[0].decode()
-    return _fetch_verified(url, cache_dir() / "artifacts" / "uv" / uv_version / name, sha256)
+    url = f"{releases_url}/{uv_version}/{name}"
+    auth = _auth_header("UV_RELEASES")
+    sha256 = fetch_url(url + ".sha256", auth).split()[0].decode()
+    return _fetch_verified(url, cache_dir() / "artifacts" / "uv" / uv_version / name, sha256, auth)
 
 
-def _pbs_checksums(release: str) -> dict[str, str]:
+def _pbs_checksums(release: str, releases_url: str = PBS_RELEASES) -> dict[str, str]:
     """artifact filename -> sha256 for a python-build-standalone release."""
     path = cache_dir() / "artifacts" / "python" / f"SHA256SUMS-{release}"
-    _fetch_verified(f"{PBS_RELEASES}/{release}/SHA256SUMS", path, None)
+    auth = _auth_header("PYTHON_BUILD_STANDALONE_RELEASES")
+    _fetch_verified(f"{releases_url}/{release}/SHA256SUMS", path, None, auth)
     sums = {}
     for line in path.read_text().splitlines():
         if fields := line.split():
@@ -97,13 +118,15 @@ def _pbs_checksums(release: str) -> dict[str, str]:
     return sums
 
 
-def resolve_python(python_version: str, release: str, goos: str, goarch: str) -> tuple[str, str]:
+def resolve_python(
+    python_version: str, release: str, goos: str, goarch: str, releases_url: str = PBS_RELEASES
+) -> tuple[str, str]:
     """Pick the PBS artifact for a requested version ("3.12" or "3.12.3").
 
     Returns (full python version, artifact filename). Prefers the stripped
     variant; a "3.X" request resolves to the newest 3.X.* in the release.
     """
-    sums = _pbs_checksums(release)
+    sums = _pbs_checksums(release, releases_url)
     triple = target_triple(goos, goarch)
     pattern = re.compile(
         rf"cpython-({re.escape(python_version)}(?:\.\d+)*)\+{release}-{triple}"
@@ -123,7 +146,10 @@ def resolve_python(python_version: str, release: str, goos: str, goarch: str) ->
     return full, variants.get(True) or variants[False]
 
 
-def fetch_python(artifact: str, release: str) -> Path:
-    sha256 = _pbs_checksums(release)[artifact]
-    url = f"{PBS_RELEASES}/{release}/{artifact}"
-    return _fetch_verified(url, cache_dir() / "artifacts" / "python" / release / artifact, sha256)
+def fetch_python(artifact: str, release: str, releases_url: str = PBS_RELEASES) -> Path:
+    sha256 = _pbs_checksums(release, releases_url)[artifact]
+    url = f"{releases_url}/{release}/{artifact}"
+    auth = _auth_header("PYTHON_BUILD_STANDALONE_RELEASES")
+    return _fetch_verified(
+        url, cache_dir() / "artifacts" / "python" / release / artifact, sha256, auth
+    )

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -78,6 +78,46 @@ expose = "all"
     assert set(config.expose) == {"python", "python-path", "cache", "metadata"}
 
 
+def test_releases_url_defaults(tmp_path):
+    config = load_config(
+        write_pyproject(
+            tmp_path,
+            """
+[project]
+name = "demo"
+version = "0.1.0"
+
+[project.scripts]
+demo = "demo:main"
+""",
+        )
+    )
+    assert config.uv_releases_url == "https://github.com/astral-sh/uv/releases/download"
+    assert config.python_build_standalone_releases_url == (
+        "https://github.com/astral-sh/python-build-standalone/releases/download"
+    )
+
+
+def test_releases_url_overrides_strip_trailing_slash(tmp_path):
+    config = load_config(
+        write_pyproject(
+            tmp_path,
+            """
+[project]
+name = "demo"
+version = "0.1.0"
+
+[tool.axe]
+entrypoint = "demo"
+uv-releases-url = "https://mirror.corp/uv/"
+python-build-standalone-releases-url = "https://mirror.corp/pbs"
+""",
+        )
+    )
+    assert config.uv_releases_url == "https://mirror.corp/uv"
+    assert config.python_build_standalone_releases_url == "https://mirror.corp/pbs"
+
+
 def test_no_entrypoint_errors(tmp_path):
     with pytest.raises(ConfigError, match="no entrypoint"):
         load_config(write_pyproject(tmp_path, '[project]\nname = "demo"\nversion = "0.1.0"\n'))

--- a/tests/test_fetch.py
+++ b/tests/test_fetch.py
@@ -1,0 +1,73 @@
+import base64
+
+import pytest
+
+from axe import fetch
+from axe.fetch import _auth_header, fetch_url, fetch_uv
+
+
+def test_auth_header_absent_by_default(monkeypatch):
+    monkeypatch.delenv("UV_RELEASES_USERNAME", raising=False)
+    monkeypatch.delenv("UV_RELEASES_PASSWORD", raising=False)
+    assert _auth_header("UV_RELEASES") is None
+
+
+@pytest.mark.parametrize("prefix", ["UV_RELEASES", "PYTHON_BUILD_STANDALONE_RELEASES"])
+def test_auth_header_from_env(monkeypatch, prefix):
+    monkeypatch.setenv(f"{prefix}_USERNAME", "alice")
+    monkeypatch.setenv(f"{prefix}_PASSWORD", "s3cret")
+    header = _auth_header(prefix)
+    assert header == "Basic " + base64.b64encode(b"alice:s3cret").decode()
+
+
+def test_auth_header_password_only(monkeypatch):
+    monkeypatch.delenv("UV_RELEASES_USERNAME", raising=False)
+    monkeypatch.setenv("UV_RELEASES_PASSWORD", "token")
+    assert _auth_header("UV_RELEASES") == "Basic " + base64.b64encode(b":token").decode()
+
+
+def test_fetch_url_sends_authorization(monkeypatch):
+    seen = {}
+
+    class FakeResponse:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *args):
+            return False
+
+        def read(self):
+            return b"payload"
+
+    def fake_urlopen(request, timeout):
+        seen["url"] = request.full_url
+        seen["auth"] = request.get_header("Authorization")
+        return FakeResponse()
+
+    monkeypatch.setattr(fetch.urllib.request, "urlopen", fake_urlopen)
+    assert fetch_url("https://mirror.corp/file", "Basic abc") == b"payload"
+    assert seen == {"url": "https://mirror.corp/file", "auth": "Basic abc"}
+
+
+def test_fetch_uv_uses_custom_releases_url(monkeypatch, tmp_path):
+    monkeypatch.setenv("AXE_CACHE_DIR", str(tmp_path))
+    monkeypatch.setenv("UV_RELEASES_USERNAME", "alice")
+    monkeypatch.setenv("UV_RELEASES_PASSWORD", "s3cret")
+    calls = []
+
+    def fake_fetch_url(url, auth=None):
+        calls.append((url, auth))
+        data = b"uv archive bytes"
+        if url.endswith(".sha256"):
+            import hashlib
+
+            return hashlib.sha256(data).hexdigest().encode() + b"  file"
+        return data
+
+    monkeypatch.setattr(fetch, "fetch_url", fake_fetch_url)
+    path = fetch_uv("0.10.6", "linux", "amd64", "https://mirror.corp/uv")
+
+    expected_auth = "Basic " + base64.b64encode(b"alice:s3cret").decode()
+    assert all(url.startswith("https://mirror.corp/uv/0.10.6/uv-") for url, _ in calls)
+    assert all(auth == expected_auth for _, auth in calls)
+    assert path.read_bytes() == b"uv archive bytes"

--- a/tests/test_payload.py
+++ b/tests/test_payload.py
@@ -72,7 +72,7 @@ SUMS = {
 
 
 def test_resolve_python(monkeypatch):
-    monkeypatch.setattr(fetch, "_pbs_checksums", lambda release: SUMS)
+    monkeypatch.setattr(fetch, "_pbs_checksums", lambda release, releases_url=None: SUMS)
 
     # Minor pin resolves to the newest patch; stripped preferred when present.
     version, artifact = fetch.resolve_python("3.12", "20260623", "darwin", "arm64")


### PR DESCRIPTION
## Summary

Build machines in network-isolated environments often can't reach github.com and must fetch through an internal mirror (Artifactory, Nexus, a plain file server behind a proxy). This PR makes the two build-time download locations configurable:

- `[tool.axe] uv-releases-url` — replaces `https://github.com/astral-sh/uv/releases/download`
- `[tool.axe] python-build-standalone-releases-url` — replaces `https://github.com/astral-sh/python-build-standalone/releases/download`

The mirror must mirror the GitHub release layout (`/<tag>/<artifact>`, plus `.sha256` files for uv and `SHA256SUMS` for python-build-standalone). Downloads stay checksum-verified; since the checksum files come from the same mirror, this catches corruption and incomplete mirroring (not a malicious mirror — use a trusted one).

If the mirror needs HTTP Basic auth, credentials come from environment variables (never `pyproject.toml`, where they'd be committed):

- `UV_RELEASES_USERNAME` / `UV_RELEASES_PASSWORD`
- `PYTHON_BUILD_STANDALONE_RELEASES_USERNAME` / `PYTHON_BUILD_STANDALONE_RELEASES_PASSWORD`

Key names use kebab-case to match the existing `[tool.axe]` options (`uv-version`, `python-release`).

## Changes

- `fetch.py`: `fetch_uv` / `fetch_python` / `resolve_python` take a `releases_url` (defaulting to the GitHub URLs); `fetch_url` can attach a Basic `Authorization` header built from the env vars
- `config.py`: new `BuildConfig` fields parsed from `[tool.axe]` (trailing slashes stripped)
- `build.py`: plumbs the configured URLs into the fetches
- Docs: configuration reference (new section incl. credentials table), CLI troubleshooting pointer, README config sample, CHANGELOG

## Testing

- `uv run pytest` — 61 passed (new tests for config parsing, auth header construction, and mirror URL plumbing)
- Verified end-to-end against a local basic-auth mirror: with a fresh `AXE_CACHE_DIR`, `axe build` fetched uv + CPython exclusively from the mirror with correct `Authorization` headers and produced a working binary; missing/wrong credentials fail with `HTTP Error 401` (exit 1); a tampered mirror artifact fails with `checksum mismatch`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
