### PR TITLE
feat: honor UV_* index variables in the pip download step

### DIFF
--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -111,6 +111,27 @@ where they would be committed):
 For token-based mirrors that ignore the username, setting just the
 password variable works (an empty username is sent).
 
+## Steering uv with `UV_*` environment variables
+
+The tools `axe build` runs on the build machine — `uv build`,
+`uv pip compile`, and `pip download` — inherit your environment, so
+[uv's environment variables](https://docs.astral.sh/uv/reference/environment/)
+steer the build. Common uses:
+
+- `UV_INDEX_URL` / `UV_DEFAULT_INDEX` / `UV_EXTRA_INDEX_URL` — resolve and
+  download dependencies from a private index instead of pypi.org.
+- `UV_NATIVE_TLS=1` — use the system trust store behind a
+  TLS-intercepting corporate proxy.
+
+The dependency wheels are downloaded with pip, which ignores `UV_*`;
+axe mirrors the index variables above into `PIP_INDEX_URL` /
+`PIP_EXTRA_INDEX_URL` so the download step hits the same indexes
+resolution did. Explicitly set `PIP_*` variables take precedence.
+
+This applies to the build machine only: built binaries deliberately
+[ignore `UV_*` and `PIP_*`](runtime.md#environment-variables) on the end user's
+machine so every installation behaves identically.
+
 ## `expose`
 
 Extra `self` management commands compiled into the binary, beyond the

--- a/src/axe/proc.py
+++ b/src/axe/proc.py
@@ -33,8 +33,9 @@ def run_tool(
     env: dict[str, str] | None = None,
 ) -> str:
     """Run a tool and return its stdout. The build machine's environment is
-    inherited (env=None) so UV_*/PIP_* variables steer uv and pip; pass env
-    to substitute a modified copy."""
+    inherited (env=None) so UV_*/PIP_* variables steer uv and pip. env is
+    not merged: it replaces the entire subprocess environment, so build it
+    from a copy of os.environ (see resolve.pip_env) or PATH etc. are lost."""
     if output.verbose():
         output.progress(f"$ {' '.join(str(c) for c in cmd)}")
     stderr = None if output.verbose() else subprocess.PIPE

--- a/src/axe/proc.py
+++ b/src/axe/proc.py
@@ -30,8 +30,11 @@ def run_tool(
     timeout: float,
     cwd: Path | None = None,
     hint: str = "",
+    env: dict[str, str] | None = None,
 ) -> str:
-    """Run a tool and return its stdout."""
+    """Run a tool and return its stdout. The build machine's environment is
+    inherited (env=None) so UV_*/PIP_* variables steer uv and pip; pass env
+    to substitute a modified copy."""
     if output.verbose():
         output.progress(f"$ {' '.join(str(c) for c in cmd)}")
     stderr = None if output.verbose() else subprocess.PIPE
@@ -43,6 +46,7 @@ def run_tool(
             stderr=stderr,
             text=True,
             timeout=timeout,
+            env=env,
         )
     except subprocess.TimeoutExpired:
         raise ToolError(

--- a/src/axe/resolve.py
+++ b/src/axe/resolve.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import os
 import tempfile
 from pathlib import Path
 
@@ -37,6 +38,24 @@ def compile_requirements(uv: str, project_dir: Path, goos: str, goarch: str, pyt
         cwd=project_dir,
         hint=NETWORK_HINT,
     )
+
+
+def pip_env() -> dict[str, str] | None:
+    """Environment for the pip download step, or None to inherit as-is.
+
+    pip ignores uv's UV_* variables, so a developer who points uv at a
+    private index (UV_INDEX_URL / UV_DEFAULT_INDEX / UV_EXTRA_INDEX_URL)
+    would resolve against it but download from pypi.org. Mirror those into
+    pip's PIP_* equivalents; explicitly set PIP_* variables win.
+    """
+    mapped = {
+        "PIP_INDEX_URL": os.environ.get("UV_INDEX_URL") or os.environ.get("UV_DEFAULT_INDEX"),
+        "PIP_EXTRA_INDEX_URL": os.environ.get("UV_EXTRA_INDEX_URL"),
+    }
+    mapped = {k: v for k, v in mapped.items() if v and k not in os.environ}
+    if not mapped:
+        return None
+    return {**os.environ, **mapped}
 
 
 def pinned_count(requirements: str) -> int:
@@ -98,6 +117,7 @@ def download_wheels(
             what=f"downloading dependency wheels for {goos}/{goarch}",
             timeout=DOWNLOAD_TIMEOUT,
             hint=("A dependency may not publish wheels for that platform. " + NETWORK_HINT),
+            env=pip_env(),
         )
     finally:
         Path(reqs_path).unlink(missing_ok=True)

--- a/tests/test_resolve.py
+++ b/tests/test_resolve.py
@@ -1,0 +1,61 @@
+import sys
+
+from axe.proc import run_tool
+from axe.resolve import pip_env
+
+UV_PIP_VARS = (
+    "UV_INDEX_URL",
+    "UV_DEFAULT_INDEX",
+    "UV_EXTRA_INDEX_URL",
+    "PIP_INDEX_URL",
+    "PIP_EXTRA_INDEX_URL",
+)
+
+
+def clear_index_vars(monkeypatch):
+    for var in UV_PIP_VARS:
+        monkeypatch.delenv(var, raising=False)
+
+
+def test_pip_env_inherits_when_nothing_to_map(monkeypatch):
+    clear_index_vars(monkeypatch)
+    assert pip_env() is None
+
+
+def test_pip_env_mirrors_uv_index_vars(monkeypatch):
+    clear_index_vars(monkeypatch)
+    monkeypatch.setenv("UV_INDEX_URL", "https://mirror.corp/simple")
+    monkeypatch.setenv("UV_EXTRA_INDEX_URL", "https://extra.corp/simple")
+    env = pip_env()
+    assert env["PIP_INDEX_URL"] == "https://mirror.corp/simple"
+    assert env["PIP_EXTRA_INDEX_URL"] == "https://extra.corp/simple"
+
+
+def test_pip_env_maps_default_index(monkeypatch):
+    clear_index_vars(monkeypatch)
+    monkeypatch.setenv("UV_DEFAULT_INDEX", "https://mirror.corp/simple")
+    assert pip_env()["PIP_INDEX_URL"] == "https://mirror.corp/simple"
+
+
+def test_pip_env_prefers_uv_index_url_over_default_index(monkeypatch):
+    clear_index_vars(monkeypatch)
+    monkeypatch.setenv("UV_INDEX_URL", "https://legacy.corp/simple")
+    monkeypatch.setenv("UV_DEFAULT_INDEX", "https://new.corp/simple")
+    assert pip_env()["PIP_INDEX_URL"] == "https://legacy.corp/simple"
+
+
+def test_pip_env_explicit_pip_vars_win(monkeypatch):
+    clear_index_vars(monkeypatch)
+    monkeypatch.setenv("UV_INDEX_URL", "https://mirror.corp/simple")
+    monkeypatch.setenv("PIP_INDEX_URL", "https://pip.corp/simple")
+    assert pip_env() is None  # nothing to map: pip already configured
+
+
+def test_run_tool_inherits_environment(monkeypatch):
+    monkeypatch.setenv("UV_INDEX_URL", "https://mirror.corp/simple")
+    out = run_tool(
+        [sys.executable, "-c", "import os; print(os.environ['UV_INDEX_URL'])"],
+        what="env probe",
+        timeout=30,
+    )
+    assert out.strip() == "https://mirror.corp/simple"


### PR DESCRIPTION
## Summary

`axe build` runs its tools with the inherited environment, so `UV_*` variables already steer `uv build` and `uv pip compile`. But dependency wheels are downloaded with **pip** (via `uv tool run --from pip`), which ignores `UV_*` — a developer pointing uv at a private index would resolve against it yet download from pypi.org (or fail outright in a network-isolated environment).

## Changes

- **`resolve.pip_env()`**: mirrors `UV_INDEX_URL` / `UV_DEFAULT_INDEX` → `PIP_INDEX_URL` and `UV_EXTRA_INDEX_URL` → `PIP_EXTRA_INDEX_URL` for the pip download step, so it hits the same indexes resolution did. Explicitly set `PIP_*` variables win; when nothing needs mapping the environment is inherited untouched.
- **`proc.run_tool`**: gains an optional `env` parameter, and its docstring now states the inheritance contract (env vars pass through at build time — unlike the runtime stub, which deliberately strips `UV_*`/`PIP_*` on the end user's machine).
- **Docs**: new "Steering uv with `UV_*` environment variables" section in the configuration reference.
- **Tests**: `tests/test_resolve.py` covers the mapping, `PIP_*` precedence, and environment inheritance through `run_tool`.

## Test plan

- `uv run pytest` — 67 passed
- `uv run ruff check` / `ruff format --check` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)